### PR TITLE
fix: skip missing files instead of failing

### DIFF
--- a/lib/tasks/bsb_tasks.rake
+++ b/lib/tasks/bsb_tasks.rake
@@ -13,12 +13,22 @@ namespace :bsb do
       file_format: '.txt'
     )
 
-    require 'bsb/bank_list_generator'
-    bsb_bl_gen = BSB::BankListGenerator.load_file(bank_list_filename)
-    File.write('config/bsb_bank_list.json', bsb_bl_gen.json)
+    raise 'No bank list or bsb found' unless bank_list_filename || db_list_filename
 
-    require 'bsb/database_generator'
-    bsb_db_gen = BSB::DatabaseGenerator.load_file(db_list_filename)
-    File.write('config/bsb_db.json', bsb_db_gen.json)
+    if bank_list_filename
+      require 'bsb/bank_list_generator'
+      bsb_bl_gen = BSB::BankListGenerator.load_file(bank_list_filename)
+      File.write('config/bsb_bank_list.json', bsb_bl_gen.json)
+    else
+      $stderr.puts 'Missing bank list "KEY TO ABBREVIATIONS AND BSB NUMBERS"'
+    end
+
+    if db_list_filename
+      require 'bsb/database_generator'
+      bsb_db_gen = BSB::DatabaseGenerator.load_file(db_list_filename)
+      File.write('config/bsb_db.json', bsb_db_gen.json)
+    else
+      $stderr.puts 'Missing bsb db "BSBDirectory"'
+    end
   end
 end


### PR DESCRIPTION
One of the files is currently missing. This just updates the sync so that it skips a missing file and prints a warning. If all files are missing it raises an error.