### PR TITLE
fix (validation): fix issue with validation raising exception if nil

### DIFF
--- a/lib/bsb_number_validator.rb
+++ b/lib/bsb_number_validator.rb
@@ -4,6 +4,6 @@ require 'active_model'
 
 class BsbNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors.add(attribute, :invalid) unless BSB.lookup(value)
+    record.errors.add(attribute, :invalid) unless value.nil? || BSB.lookup(value)
   end
 end


### PR DESCRIPTION
When trying to validate a BSB, if the value is nil it raises an exception:

undefined method `gsub' for nil

from:

    def normalize(str)
      str.gsub(/[^\d]/, '')
    end
    
in bsb.rb

I picked this up in my tests:

expect(account).to validate_presence_of(:bsb)