### PR TITLE
Add update bsb Github Action

### DIFF
--- a/.github/workflows/update_bsb_db.yml
+++ b/.github/workflows/update_bsb_db.yml
@@ -1,0 +1,38 @@
+name: Update BSB DB
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 15 1,8,15,22,29 * *" # “At 15:00 on day-of-month 1, 8, 15, 22, and 29.”
+
+jobs:
+  update-bsb:
+    runs-on: ubuntu-latest
+    env:
+      AUSPAYNET_SUB_KEY: ${{secrets.AUSPAYNET_SUB_KEY}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Fetch latest contents
+        run: bundle exec rake bsb:sync_bsb_db
+
+      - name: Remove latest_update file
+        run: rm -f config/latest_update.json
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: update-bsb-db
+          title: Update BSB Database
+          body: |
+            This Pull Request was created via a Github Action.
+
+            The related workflow file is `.github/workflows/update_bsb_db.yml` and the changes are generated using the rake task `bsb:sync_bsb_db`
+
+            If you're unsure how to proceed with this PR, please see the [README](https://github.com/coinjar/bsb/blob/master/README.md#update-bsb-db)

--- a/lib/bsb/aus_pay_net/client.rb
+++ b/lib/bsb/aus_pay_net/client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require("faraday")
+
 module BSB
   module AusPayNet
     module Client


### PR DESCRIPTION
# What

A continuation on a [new rake task added](https://github.com/coinjar/bsb/pull/61)

Adds a github action that runs a few times a month and fetches the latest bsb's. If there are any changes it will raise a PR for someone with the permissions to review and merge if all looks good.

# Questions / Discussion

Should anyone be tagged for review automatically?
Do we actually want to track the latest update file rather than deleting it? Might make it a bit easier to review PR and do some spot checks 🤔 
Days chosen to run on are arbitrary, just went for something roughly once a week