### PR TITLE
feat: Use AusPayNet v2 BSBQuery API

### DIFF
--- a/lib/bsb/aus_pay_net/client.rb
+++ b/lib/bsb/aus_pay_net/client.rb
@@ -7,9 +7,6 @@ module BSB
     module Client
       class MissingSubscriptionKeyError < StandardError; end
 
-      OUTPUT_PARAM_WIDTH = 30
-      LEADER_WIDTH = OUTPUT_PARAM_WIDTH + 11
-
       Response = Struct.new(:body, keyword_init: true)
 
       def self.fetch_all_bsbs
@@ -26,13 +23,12 @@ module BSB
           }
         ) do |faraday|
           faraday.response :raise_error
+          faraday.response :json
         end
 
-        response = conn.post('/bsbquery/manual/paths/invoke') do |req|
-          req.body = { outputparam: ' ' * OUTPUT_PARAM_WIDTH }.to_json
-        end
+        response = conn.post('/BSBQuery-V2/manual/paths/invoke')
 
-        Response.new(body: response.body[LEADER_WIDTH..])
+        Response.new(body: response.body.fetch('data'))
       end
     end
   end

--- a/lib/bsb/base_generator.rb
+++ b/lib/bsb/base_generator.rb
@@ -10,8 +10,10 @@ module BSB
       @hash = hash
     end
 
-    def json
-      JSON.pretty_generate(@hash)
+    def json(sorted: false)
+      return JSON.pretty_generate(@hash) unless sorted
+
+      JSON.pretty_generate(@hash.sort.to_h)
     end
   end
 end

--- a/lib/tasks/sync_bsb_db.rake
+++ b/lib/tasks/sync_bsb_db.rake
@@ -28,7 +28,7 @@ namespace :bsb do
       }
     )
 
-    File.write(BSB::DB_FILEPATH, latest_db.json)
+    File.write(BSB::DB_FILEPATH, latest_db.json(sorted: true))
     File.write(BSB::CHANGES_FILEPATH, changes_json)
   end
 end

--- a/test/bsb/aus_pay_net/client_test.rb
+++ b/test/bsb/aus_pay_net/client_test.rb
@@ -5,7 +5,16 @@ require 'test_helper'
 
 describe BSB::AusPayNet::Client do
   describe '.fetch_all_bsbs' do
-    before { ENV['AUSPAYNET_SUB_KEY'] = 'something' }
+    before do
+      if ENV['AUSPAYNET_SUB_KEY'].nil?
+        @remove_auspay_key = true
+        ENV['AUSPAYNET_SUB_KEY'] = 'something'
+      end
+    end
+
+    after do
+      ENV.delete('AUSPAYNET_SUB_KEY') if @remove_auspay_key
+    end
 
     it 'returns the expected response' do
       VCR.use_cassette('auspaynet_fetch_all_bsbs') do

--- a/test/bsb/base_generator_test.rb
+++ b/test/bsb/base_generator_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'bsb/base_generator'
+
+describe BSB::BaseGenerator do
+  describe '#json' do
+    it 'returns a JSON string' do
+      hash = { key: 'value' }
+      generator = BSB::BaseGenerator.new(hash)
+      expected_json = <<~JSON.strip
+        {
+          "key": "value"
+        }
+      JSON
+
+      assert_equal expected_json, generator.json
+    end
+
+    it 'returns a JSON representation of the sorted hash when sorted is true' do
+      hash = { '123456' => '3', '012345' => '2', '234567' => '4', '00001' => '1' }
+      generator = BSB::BaseGenerator.new(hash)
+      expected_json = <<~JSON.strip
+        {
+          "00001": "1",
+          "012345": "2",
+          "123456": "3",
+          "234567": "4"
+        }
+      JSON
+
+      assert_equal expected_json, generator.json(sorted: true)
+    end
+
+    it 'returns a JSON representation of the unsorted hash when sorted is false' do
+      hash = { '123456' => '3', '012345' => '2', '234567' => '4', '00001' => '1' }
+      generator = BSB::BaseGenerator.new(hash)
+      expected_json = <<~JSON.strip
+        {
+          "123456": "3",
+          "012345": "2",
+          "234567": "4",
+          "00001": "1"
+        }
+      JSON
+
+      assert_equal expected_json, generator.json(sorted: false)
+    end
+  end
+end

--- a/test/fixtures/vcr_cassettes/auspaynet_fetch_all_bsbs.yml
+++ b/test/fixtures/vcr_cassettes/auspaynet_fetch_all_bsbs.yml
@@ -2,17 +2,17 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auspaynet-bicbsb-api-prod.azure-api.net/bsbquery/manual/paths/invoke
+    uri: https://auspaynet-bicbsb-api-prod.azure-api.net/BSBQuery-V2/manual/paths/invoke
     body:
-      encoding: UTF-8
-      string: '{"outputparam":"                              "}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Content-type:
       - application/json
       Ocp-apim-subscription-key:
       - "<AUSPAYNET_SUB_KEY>"
       User-Agent:
-      - Faraday v2.10.1
+      - Faraday v2.12.0
   response:
     status:
       code: 200
@@ -25,56 +25,55 @@ http_interactions:
       transfer-encoding:
       - chunked
       content-type:
-      - text/plain; charset=utf-8
+      - application/json
       content-encoding:
       - gzip
       expires:
       - "-1"
       vary:
       - Accept-Encoding
-      set-cookie:
-      - ARRAffinity=0aa69915266871205a67096b40953eafb333722c9d662666b4ee1cbd3af96c28;Path=/;HttpOnly;Secure;Domain=prod-07.australiasoutheast.logic.azure.com,
-        ARRAffinitySameSite=0aa69915266871205a67096b40953eafb333722c9d662666b4ee1cbd3af96c28;Path=/;HttpOnly;SameSite=None;Secure;Domain=prod-07.australiasoutheast.logic.azure.com
       strict-transport-security:
       - max-age=31536000; includeSubDomains
       x-ms-workflow-run-id:
-      - '08584759810780029358383571724CU01'
+      - '08584575192488054635250345459CU61'
       x-ms-correlation-id:
-      - 8d349630-46fe-44ae-9d3f-0dc53071b48e
+      - a1c9ff2c-1071-48cb-89b9-abcba0c3ca33
       x-ms-client-tracking-id:
-      - '08584759810780029358383571724CU01'
+      - '08584575192488054635250345459CU61'
       x-ms-trigger-history-name:
-      - '08584759810780029358383571724CU01'
+      - '08584575192488054635250345459CU61'
       x-ms-execution-location:
       - australiasoutheast
       x-ms-workflow-system-id:
-      - "/locations/australiasoutheast/scaleunits/prod-07/workflows/55b07bc2b01c48cea922b9673bb16c54"
+      - "/locations/australiasoutheast/scaleunits/prod-58/workflows/b6cb1d81c12f46cd9433109c878b4ca2"
       x-ms-workflow-id:
-      - 55b07bc2b01c48cea922b9673bb16c54
+      - b6cb1d81c12f46cd9433109c878b4ca2
       x-ms-workflow-version:
-      - '08584793971872858901'
+      - '08584576177772871167'
       x-ms-workflow-name:
-      - logicapp-all-wildcardquery
+      - logicapp-all-wildcardquery-V2
       x-ms-tracking-id:
-      - 8d349630-46fe-44ae-9d3f-0dc53071b48e
+      - a1c9ff2c-1071-48cb-89b9-abcba0c3ca33
       x-ms-ratelimit-burst-remaining-workflow-writes:
-      - '2999'
+      - '2044'
       x-ms-ratelimit-remaining-workflow-download-contentsize:
-      - '210888995'
-      x-ms-ratelimit-remaining-workflow-upload-contentsize:
-      - '214748112'
+      - '140739431'
       x-ms-ratelimit-time-remaining-directapirequests:
-      - '19998471'
+      - '13634951'
       x-ms-request-id:
-      - australiasoutheast:8d349630-46fe-44ae-9d3f-0dc53071b48e
+      - australiasoutheast:a1c9ff2c-1071-48cb-89b9-abcba0c3ca33
       request-context:
       - appId=cid-v1:62fce8e1-7550-4725-83ec-f11232c5768f
       date:
-      - Fri, 06 Sep 2024 12:30:08 GMT
+      - Tue, 08 Apr 2025 04:47:18 GMT
     body:
-      encoding: UTF-8
-      string: '{"outputparam":"Query results returned "}[{"BSBCode":"012-002","BSBName":"ANZ
-        Smart Choice","FiMnemonic":"ANZ","Address":"115 Pitt Street","Suburb":"Sydney","State":"NSW","Postcode":"2000","StreamCode":"PEH","lastmodified":null,"BIC":"ANZBAU3R","BICINT":"","repair":"00"},{"BSBCode":"012-003","BSBName":"Merged","FiMnemonic":"ANZ","Address":"Refer
-        to BSB 012-019","Suburb":"Sydney","State":"NSW","Postcode":"2000","StreamCode":"PEH","lastmodified":null,"BIC":"ANZBAU3R","BICINT":"","repair":"00"}]'
-  recorded_at: Fri, 06 Sep 2024 12:30:09 GMT
+      encoding: ASCII-8BIT
+      string: '{"status":"success","message":"Query executed with filters applied","timestamp":"2025-04-08T04:47:16.863","requestId":"08584575192488054635250345459CU61","data":"[{\"BSBCode\":\"942-304\",\"BSBName\":\"Bank
+        of Sydney Ltd - Doncaster\",\"FiMnemonic\":\"LBA\",\"Address\":\"Shop 1, 700
+        Doncaster Road\",\"Suburb\":\"Doncaster\",\"State\":\"VIC\",\"Postcode\":\"3108\",\"StreamCode\":\"EH\",\"lastmodified\":\"2024-03-01T06:48:44\",\"BIC\":\"LIKIAU2S\",\"BICINT\":\"\",\"repair\":\"0\",\"FIName\":\"Bank
+        of Sydney Ltd\"},{\"BSBCode\":\"942-303\",\"BSBName\":\"Bank of Sydney Ltd
+        - Northcote\",\"FiMnemonic\":\"LBA\",\"Address\":\"25 Nthcote Ctr High & Seperation
+        St\",\"Suburb\":\"Northcote\",\"State\":\"VIC\",\"Postcode\":\"3070\",\"StreamCode\":\"EH\",\"lastmodified\":\"2024-03-01T06:48:44\",\"BIC\":\"LIKIAU2S\",\"BICINT\":\"\",\"repair\":\"0\",\"FIName\":\"Bank
+        of Sydney Ltd\"}]"}'
+  recorded_at: Tue, 08 Apr 2025 04:47:19 GMT
 recorded_with: VCR 6.3.1

--- a/test/tasks/sync_bsb_db_test.rb
+++ b/test/tasks/sync_bsb_db_test.rb
@@ -6,10 +6,15 @@ require 'bsb/database_generator'
 
 describe 'sync_bsb_db rake task' do # rubocop:disable Metrics/BlockLength
   before do
+    @old_sub_key = ENV.fetch('AUSPAYNET_SUB_KEY', nil)
     ENV.update('AUSPAYNET_SUB_KEY' => 'something')
     Rake.application.rake_require('../lib/tasks/sync_bsb_db')
     Rake::Task['bsb:sync_bsb_db'].reenable
     File.write('test/tmp/bsb_db.json', File.read('test/fixtures/bsb_db.json'))
+  end
+
+  after do
+    ENV['AUSPAYNET_SUB_KEY'] = @old_sub_key
   end
 
   let(:auspaynet_bsb_client_response) do


### PR DESCRIPTION
# What

- Updates the BSBQuery client to use the newly released v2 API
- Sorts the bsb_db data before writing it

# Why v2?

AusPayNet recently released a v2 API. 
The way I read it v1 will be available until August 2025 so might as well update. 
V2 also improves the API behaviour a little by:
- Returning a well formed JSON response
- Removing the usage of the output param

# Why sort?

To prevent big releases that are difficult to grok even though there's not too many changes. This [happened recently](https://github.com/coinjar/bsb/commit/3c846ebd1eb54cb2166e456c74eae4978364d3a4) when it looks like the API changed the order it returned results. This just makes the update more resilient and hopefully gives users more confidence when updating versions.

This will probably trigger a new release PR if/once merged on the next workflow run because ordering will change again but from then on should be stable.

# Discussion

Does anyone have concerns with with committing the `latest_update.json` config file that the updater generates? My 2 cents is it would be useful again when reviewing version bumps and I'd be happy to add a commit to this PR to add it, but if there's issues with it, I won't worry about. 