### PR TITLE
fix: restore published release trigger for workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Gem
 on:
   workflow_dispatch:
   release:
-    types: [released]
+    types: [published, created]
 
 jobs:
   publish:


### PR DESCRIPTION
For #75 this is the recommendation from Aider on Claude 3.7