### PR TITLE
chore: Add dependabot for github actions maintenance, monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+registries:
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    insecure-external-code-execution: allow
+    registries: "*"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
So that we don't have to manually do https://github.com/coinjar/bsb/pull/133