### PR TITLE
chore(fix): Update CI to actions/@v5 for Node 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         ruby: [ '3.2', '3.3', '3.4' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/update_bsb_db.yml
+++ b/.github/workflows/update_bsb_db.yml
@@ -12,7 +12,7 @@ jobs:
       AUSPAYNET_SUB_KEY: ${{secrets.AUSPAYNET_SUB_KEY}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Cleans up these warnings:
<img width="1526" height="352" alt="Screenshot 2026-05-05 at 11 12 21 am" src="https://github.com/user-attachments/assets/66628f25-e5b3-40ae-a1d0-d20eb9388074" />
